### PR TITLE
仕様変更：AbstractDao.CommandCollectionをprivateスコープに変更。#3

### DIFF
--- a/Sources/OrmTxcSql/Daos/AbstractDao.cs
+++ b/Sources/OrmTxcSql/Daos/AbstractDao.cs
@@ -16,7 +16,7 @@ namespace OrmTxcSql.Daos
     {
 
         IEnumerable<IDbCommand> IDao.Commands { get => this.CommandCollection; }
-        protected readonly ICollection<IDbCommand> CommandCollection;
+        private readonly IEnumerable<IDbCommand> CommandCollection;
 
         protected TDbCommand Command { get; set; } = new TDbCommand();
 


### PR DESCRIPTION
・サブクラスからもCommandCollectionを参照する想定だったが、参照する状況が思い当たらないので、スコープを変更（protected→private）
・Daoの機能を拡張する際に複数Commandを使用したい場合には、IDao.Commandsの参照先を上書きする方針とする。