### PR TITLE
機能改善：AbstractEntityExtensionsを拡張（等しい属性値を持つかどうかを戻すメソッドを追加） for issue #14

### DIFF
--- a/Sources/OrmTxcSql/Daos/AbstractDao.cs
+++ b/Sources/OrmTxcSql/Daos/AbstractDao.cs
@@ -131,7 +131,7 @@ namespace OrmTxcSql.Daos
             TEntity result = this.SelectByPk(entity);
             if (result == null)
             {
-                if (entity.IsEquivalentTo(new TEntity()))
+                if (entity.HasEqualPropertyValues(new TEntity()))
                 {
                     // 引数のエンティティが初期状態と等価な場合、INSERT文を実行しない。
                     return 0;
@@ -144,7 +144,7 @@ namespace OrmTxcSql.Daos
             }
             else
             {
-                if (entity.IsEquivalentTo(result))
+                if (entity.HasEqualPropertyValues(result))
                 {
                     // 引数のエンティティが検索結果と等価な場合、UPDATE文を実行しない。
                     return 0;

--- a/Sources/OrmTxcSql/Entities/AbstractEntityExtensions.cs
+++ b/Sources/OrmTxcSql/Entities/AbstractEntityExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using OrmTxcSql.Utils;
@@ -35,27 +34,6 @@ namespace OrmTxcSql.Entities
         public static bool HasEqualPropertyValues<TEntity>(this TEntity obj1, TEntity obj2, IEnumerable<PropertyInfo> properties)
             where TEntity : AbstractEntity
         {
-            // 比較対象の属性値を取得する。
-            IEnumerable<object> values1 = properties.Select(prop => prop.GetValue(obj1));
-            IEnumerable<object> values2 = properties.Select(prop => prop.GetValue(obj2));
-            // 比較する。
-            bool equivalent = Enumerable.SequenceEqual(values1, values2, new AttributeEqualityComparer());
-            // 結果を戻す。
-            return equivalent;
-        }
-
-        /// <summary>
-        /// エンティティが等価かどうかを判定する。
-        /// </summary>
-        /// <returns></returns>
-        /// <remarks>
-        /// このメソッドにおける「等価」とは、エンティティのメタ情報（DBにおける共通項目）以外の値が等しいという意味である。
-        /// つまり、「等価」なエンティティでUpdateByPk(E)を実行した場合、共通項目以外が更新されない。
-        /// </remarks>
-        [Obsolete("HasEqualPropertyValuesに移行してください。")]
-        internal static bool IsEquivalentTo<TEntity>(this TEntity obj1, TEntity obj2) where TEntity : AbstractEntity
-        {
-            PropertyInfo[] properties = EntityUtils.GetColumnAttributes<TEntity>().ToArray();
             // 比較対象の属性値を取得する。
             IEnumerable<object> values1 = properties.Select(prop => prop.GetValue(obj1));
             IEnumerable<object> values2 = properties.Select(prop => prop.GetValue(obj2));

--- a/Sources/OrmTxcSql/Entities/AbstractEntityExtensions.cs
+++ b/Sources/OrmTxcSql/Entities/AbstractEntityExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using OrmTxcSql.Utils;
@@ -9,8 +10,39 @@ namespace OrmTxcSql.Entities
     /// <summary>
     /// AbstractEntityの拡張メソッドを定義します。（静的クラス）
     /// </summary>
-    internal static class AbstractEntityExtensions
+    public static class AbstractEntityExtensions
     {
+        /// <summary>
+        /// 等しい属性値を持つかどうかを戻す。
+        /// </summary>
+        /// <typeparam name="TEntity"></typeparam>
+        /// <param name="obj1"></param>
+        /// <param name="obj2"></param>
+        /// <returns></returns>
+        /// <remarks><see cref="EntityUtils.GetColumnAttributes{TEntity}"/>で取得されるすべてのプロパティを比較します。</remarks>
+        public static bool HasEqualPropertyValues<TEntity>(this TEntity obj1, TEntity obj2)
+            where TEntity : AbstractEntity
+            => HasEqualPropertyValues(obj1, obj2, EntityUtils.GetColumnAttributes<TEntity>().ToArray());
+        /// <summary>
+        /// 等しい属性値を持つかどうかを戻す。
+        /// </summary>
+        /// <typeparam name="TEntity"></typeparam>
+        /// <param name="obj1"></param>
+        /// <param name="obj2"></param>
+        /// <param name="properties">比較するプロパティ</param>
+        /// <returns></returns>
+        /// <remarks><paramref name="properties"/>で与えられたプロパティを比較します。</remarks>
+        public static bool HasEqualPropertyValues<TEntity>(this TEntity obj1, TEntity obj2, IEnumerable<PropertyInfo> properties)
+            where TEntity : AbstractEntity
+        {
+            // 比較対象の属性値を取得する。
+            IEnumerable<object> values1 = properties.Select(prop => prop.GetValue(obj1));
+            IEnumerable<object> values2 = properties.Select(prop => prop.GetValue(obj2));
+            // 比較する。
+            bool equivalent = Enumerable.SequenceEqual(values1, values2, new AttributeEqualityComparer());
+            // 結果を戻す。
+            return equivalent;
+        }
 
         /// <summary>
         /// エンティティが等価かどうかを判定する。
@@ -20,6 +52,7 @@ namespace OrmTxcSql.Entities
         /// このメソッドにおける「等価」とは、エンティティのメタ情報（DBにおける共通項目）以外の値が等しいという意味である。
         /// つまり、「等価」なエンティティでUpdateByPk(E)を実行した場合、共通項目以外が更新されない。
         /// </remarks>
+        [Obsolete("HasEqualPropertyValuesに移行してください。")]
         internal static bool IsEquivalentTo<TEntity>(this TEntity obj1, TEntity obj2) where TEntity : AbstractEntity
         {
             PropertyInfo[] properties = EntityUtils.GetColumnAttributes<TEntity>().ToArray();


### PR DESCRIPTION
機能改善：AbstractEntityExtensionsを拡張（等しい属性値を持つかどうかを戻すメソッドを追加） for issue #14 
・Column属性が定義されているプロパティについて比較する。
・クラスに定義されているColumn属性について、すべてを比較／一部を比較を指定可能。
・以前使用していた IsEquivalentTo は廃止。（ロジックを削除）
