### PR TITLE
機能改善：OrmTxcSql.NpgsqlでSSL通信をしたい（信頼されないSSL証明書も使用可としたい） for issue #13

### DIFF
--- a/Sources/OrmTxcSql.Npgsql/Data/NpgsqlServer.cs
+++ b/Sources/OrmTxcSql.Npgsql/Data/NpgsqlServer.cs
@@ -13,6 +13,50 @@ namespace OrmTxcSql.Npgsql.Data
     /// </summary>
     public class NpgsqlServer : DbServer<NpgsqlConnection>
     {
+        /// <summary>
+        /// ［拡張］接続のオープン、クローズのみ管理する。
+        /// </summary>
+        public void Connect(Action<NpgsqlConnection> action)
+        {
+            using (var connection = new NpgsqlConnection())
+            {
+                connection.ConnectionString = this.DataSource.GetConnectionString();
+                connection.Open();
+                //
+                // メイン処理
+                try
+                {
+                    // メイン処理を実行する。
+                    action(connection);
+                    //
+                }
+                catch (NpgsqlException)
+                {
+                    // 例外を投げる。（丸投げ）
+                    throw;
+                }
+                catch (Exception)
+                {
+                    // 例外を投げる。（丸投げ）
+                    throw;
+                }
+                // 接続を閉じる。
+                this.CloseConnection(connection);
+            }
+        }
+        /// <summary>
+        /// 接続を閉じる。
+        /// </summary>
+        /// <param name="connection"></param>
+        private void CloseConnection(NpgsqlConnection connection)
+        {
+            // 接続を閉じる。
+            if (connection.State == ConnectionState.Open)
+            {
+                connection.Close();
+            }
+        }
+
         private static IParameterValueConverter ParameterValueConverter { get; set; } = new NpgsqlParameterValueConverter();
 
         /// <summary>
@@ -79,50 +123,6 @@ namespace OrmTxcSql.Npgsql.Data
             IDataParameter parameter = new NpgsqlParameter(parameterName, dbType);
             parameter.Value = NpgsqlServer.ParameterValueConverter.Convert(value, null, null);
             DbServer<NpgsqlConnection>.AddParameterIfNotExists(command, parameter);
-        }
-
-        /// <summary>
-        /// ［拡張］接続のオープン、クローズのみ管理する。
-        /// </summary>
-        public void Connect(Action<NpgsqlConnection> action)
-        {
-            using (var connection = new NpgsqlConnection())
-            {
-                connection.ConnectionString = this.DataSource.GetConnectionString();
-                connection.Open();
-                //
-                // メイン処理
-                try
-                {
-                    // メイン処理を実行する。
-                    action(connection);
-                    //
-                }
-                catch (NpgsqlException)
-                {
-                    // 例外を投げる。（丸投げ）
-                    throw;
-                }
-                catch (Exception)
-                {
-                    // 例外を投げる。（丸投げ）
-                    throw;
-                }
-                // 接続を閉じる。
-                this.CloseConnection(connection);
-            }
-        }
-        /// <summary>
-        /// 接続を閉じる。
-        /// </summary>
-        /// <param name="connection"></param>
-        private void CloseConnection(NpgsqlConnection connection)
-        {
-            // 接続を閉じる。
-            if (connection.State == ConnectionState.Open)
-            {
-                connection.Close();
-            }
         }
 
         #region "更新系処理に関する処理"

--- a/Sources/OrmTxcSql.Npgsql/Data/NpgsqlServer.cs
+++ b/Sources/OrmTxcSql.Npgsql/Data/NpgsqlServer.cs
@@ -1,10 +1,14 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using System.Linq;
 using System.Reflection;
 using Npgsql;
 using NpgsqlTypes;
+using OrmTxcSql.Daos;
 using OrmTxcSql.Data;
+using OrmTxcSql.Utils;
 
 namespace OrmTxcSql.Npgsql.Data
 {
@@ -14,6 +18,120 @@ namespace OrmTxcSql.Npgsql.Data
     public class NpgsqlServer : DbServer<NpgsqlConnection>
     {
         /// <summary>
+        /// トランザクション管理下において、<paramref name="action"/>を実行する。
+        /// </summary>
+        /// <param name="daos">トランザクションに参加する<see cref="IDao"/>のコレクション</param>
+        /// <param name="action">トランザクション管理下で実行される処理</param>
+        public override void Execute(IEnumerable<IDao> daos, Action<IDbTransaction> action)
+        {
+            using (var connection = new NpgsqlConnection())
+            {
+                connection.ConnectionString = this.DataSource.GetConnectionString();
+                connection.UserCertificateValidationCallback = this.DataSource.GetRemoteCertificateValidationCallback();
+                connection.Open();
+                using (var tx = connection.BeginTransaction())
+                {
+                    // 前処理：コマンドに接続とトランザクションを設定する。
+                    foreach (IDao dao in daos)
+                    {
+                        IEnumerable<IDbCommand> commands = dao.Commands ?? Enumerable.Empty<IDbCommand>();
+                        foreach (IDbCommand command in commands)
+                        {
+                            // 接続を設定する。
+                            command.Connection = connection;
+                            // トランザクションを設定する。
+                            command.Transaction = tx;
+                        }
+                    }
+                    //
+                    // メイン処理：実装クラスのexecute()を実行する。
+                    try
+                    {
+                        // メイン処理を実行する。
+                        action(tx);
+                        //
+                        // トランザクションをコミットする。
+                        NpgsqlTransaction npgsqlTx = tx as NpgsqlTransaction;
+                        this.Commit(npgsqlTx);
+                    }
+                    catch (DbException ex)
+                    {
+                        LogUtils.GetErrorLogger().Error(ex);
+                        // トランザクションをロールバックする。
+                        this.Rollback(tx);
+                        //
+                        // 例外を投げる。（丸投げ）
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        LogUtils.GetErrorLogger().Error(ex);
+                        // トランザクションをロールバックする。
+                        this.Rollback(tx);
+                        //
+                        // 例外を投げる。（丸投げ）
+                        throw;
+                    }
+                }
+                // 
+                // 接続を閉じる。
+                this.CloseConnection(connection);
+            }
+        }
+        /// <summary>
+        /// トランザクションをコミットする。
+        /// </summary>
+        /// <param name="tx"></param>
+        private void Commit(NpgsqlTransaction tx)
+        {
+            try
+            {
+                // トランザクションをコミットする。
+                if (!tx.IsCompleted)
+                {
+                    tx.CommitAsync();
+                }
+            }
+            catch (InvalidOperationException ex)
+            {
+                // トランザクションは、既にコミットまたはロールバックされています。
+                // または、接続が切断されています。
+                LogUtils.GetErrorLogger().Error(ex);
+            }
+            catch (Exception ex)
+            {
+                // トランザクションのコミット中にエラーが発生しました。
+                LogUtils.GetErrorLogger().Error(ex);
+            }
+        }
+        /// <summary>
+        /// トランザクションをロールバックする。
+        /// </summary>
+        /// <param name="tx"></param>
+        private void Rollback(NpgsqlTransaction tx)
+        {
+            try
+            {
+                // トランザクションをロールバックする。
+                if (!tx.IsCompleted)
+                {
+                    tx.RollbackAsync();
+                }
+            }
+            catch (InvalidOperationException ex)
+            {
+                // トランザクションは、既にコミットまたはロールバックされています。
+                // または、接続が切断されています。
+                LogUtils.GetErrorLogger().Error(ex);
+            }
+            catch (Exception ex)
+            {
+                // トランザクションのロールバック中にエラーが発生しました。
+                LogUtils.GetErrorLogger().Error(ex);
+            }
+        }
+
+        /// <summary>
         /// ［拡張］接続のオープン、クローズのみ管理する。
         /// </summary>
         public void Connect(Action<NpgsqlConnection> action)
@@ -21,6 +139,7 @@ namespace OrmTxcSql.Npgsql.Data
             using (var connection = new NpgsqlConnection())
             {
                 connection.ConnectionString = this.DataSource.GetConnectionString();
+                connection.UserCertificateValidationCallback = this.DataSource.GetRemoteCertificateValidationCallback();
                 connection.Open();
                 //
                 // メイン処理

--- a/Sources/OrmTxcSql.Npgsql/Data/NpgsqlServer.cs
+++ b/Sources/OrmTxcSql.Npgsql/Data/NpgsqlServer.cs
@@ -8,10 +8,11 @@ using OrmTxcSql.Data;
 
 namespace OrmTxcSql.Npgsql.Data
 {
-
+    /// <summary>
+    /// DBMS（PostgreSQL）との接続、トランザクション管理を行うクラス。
+    /// </summary>
     public class NpgsqlServer : DbServer<NpgsqlConnection>
     {
-
         private static IParameterValueConverter ParameterValueConverter { get; set; } = new NpgsqlParameterValueConverter();
 
         /// <summary>
@@ -125,6 +126,12 @@ namespace OrmTxcSql.Npgsql.Data
         }
 
         #region "更新系処理に関する処理"
+        /// <summary>
+        /// <see cref="DbServer{TConnection}.ExecuteNonQuery(IDbCommand, bool)"/>
+        /// </summary>
+        /// <param name="command"></param>
+        /// <param name="enableOptimisticConcurrency"></param>
+        /// <returns></returns>
         public static int ExecuteNonQuery(NpgsqlCommand command, bool enableOptimisticConcurrency = true)
         {
             try
@@ -154,7 +161,5 @@ namespace OrmTxcSql.Npgsql.Data
             }
         }
         #endregion
-
     }
-
 }

--- a/Sources/OrmTxcSql/Data/DataSource.cs
+++ b/Sources/OrmTxcSql/Data/DataSource.cs
@@ -1,4 +1,6 @@
-﻿namespace OrmTxcSql.Data
+﻿using System.Net.Security;
+
+namespace OrmTxcSql.Data
 {
 
     /// <summary>
@@ -23,6 +25,14 @@
         /// </remarks>
         public abstract string GetConnectionString();
 
+        /// <summary>
+        /// <see cref="RemoteCertificateValidationCallback"/>を取得します。
+        /// </summary>
+        /// <returns></returns>
+        public virtual RemoteCertificateValidationCallback GetRemoteCertificateValidationCallback()
+        {
+            return null;
+        }
     }
 
 }


### PR DESCRIPTION
機能改善：OrmTxcSql.NpgsqlでSSL通信をしたい（信頼されないSSL証明書も使用可としたい） for issue #13

使用方法：
・DataSource.GetConnectionString()でSSLモードを指定した接続文字列を戻す。
・DataSource.GetRemoteCertificateValidationCallback()で
　サーバ証明書の検証処理を定義したRemoteCertificateValidationCallbackを戻す。
