### PR TITLE
仕様変更：AbstractDao<TEntity, TDbCommand, TDbDataAdapter>#InsertOrUpdate(TEntity)を見直し for issue #18

### DIFF
--- a/Sources/OrmTxcSql.DB2/OrmTxcSql.DB2.nuspec
+++ b/Sources/OrmTxcSql.DB2/OrmTxcSql.DB2.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>OrmTxcSql.DB2</id>
-    <version>1.0.10</version>
+    <version>1.1.0</version>
     <authors>tanoue13</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
@@ -11,7 +11,7 @@
     <tags>orm transaction sql ibm iSeries db2</tags>
     <dependencies>
       <group targetFramework=".NETFramework4.6.1">
-        <dependency id="OrmTxcSql" version="1.0.10" />
+        <dependency id="OrmTxcSql" version="1.1.0" />
       </group>
     </dependencies>
   </metadata>

--- a/Sources/OrmTxcSql.DB2/Properties/AssemblyInfo.cs
+++ b/Sources/OrmTxcSql.DB2/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // すべての値を指定するか、次を使用してビルド番号とリビジョン番号を既定に設定できます
 // 既定値にすることができます:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.10")]
-[assembly: AssemblyFileVersion("1.0.10")]
+[assembly: AssemblyVersion("1.1.0")]
+[assembly: AssemblyFileVersion("1.1.0")]

--- a/Sources/OrmTxcSql.Npgsql/OrmTxcSql.Npgsql.nuspec
+++ b/Sources/OrmTxcSql.Npgsql/OrmTxcSql.Npgsql.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>OrmTxcSql.Npgsql</id>
-    <version>1.0.10.1</version>
+    <version>1.1.0</version>
     <authors>tanoue13</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
@@ -11,7 +11,7 @@
     <tags>orm transaction sql npgsql postgresql</tags>
     <dependencies>
       <group targetFramework=".NETFramework4.6.1">
-        <dependency id="OrmTxcSql" version="1.0.10" />
+        <dependency id="OrmTxcSql" version="1.1.0" />
         <dependency id="Npgsql"    version="4.1.11" />
       </group>
     </dependencies>

--- a/Sources/OrmTxcSql.Npgsql/Properties/AssemblyInfo.cs
+++ b/Sources/OrmTxcSql.Npgsql/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // すべての値を指定するか、次を使用してビルド番号とリビジョン番号を既定に設定できます
 // 既定値にすることができます:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.10.1")]
-[assembly: AssemblyFileVersion("1.0.10.1")]
+[assembly: AssemblyVersion("1.1.0")]
+[assembly: AssemblyFileVersion("1.1.0")]

--- a/Sources/OrmTxcSql.SqlClient/OrmTxcSql.SqlClient.nuspec
+++ b/Sources/OrmTxcSql.SqlClient/OrmTxcSql.SqlClient.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>OrmTxcSql.SqlClient</id>
-    <version>1.0.10</version>
+    <version>1.1.0</version>
     <authors>tanoue13</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
@@ -11,7 +11,7 @@
     <tags>orm transaction sql SQLServer SqlClient</tags>
     <dependencies>
       <group targetFramework=".NETFramework4.6.1">
-        <dependency id="OrmTxcSql" version="1.0.10" />
+        <dependency id="OrmTxcSql" version="1.1.0" />
       </group>
     </dependencies>
   </metadata>

--- a/Sources/OrmTxcSql.SqlClient/Properties/AssemblyInfo.cs
+++ b/Sources/OrmTxcSql.SqlClient/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // すべての値を指定するか、次を使用してビルド番号とリビジョン番号を既定に設定できます
 // 既定値にすることができます:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.10")]
-[assembly: AssemblyFileVersion("1.0.10")]
+[assembly: AssemblyVersion("1.1.0")]
+[assembly: AssemblyFileVersion("1.1.0")]

--- a/Sources/OrmTxcSql/Daos/AbstractDao.cs
+++ b/Sources/OrmTxcSql/Daos/AbstractDao.cs
@@ -126,7 +126,7 @@ namespace OrmTxcSql.Daos
         /// </summary>
         /// <param name="entity"></param>
         /// <returns>影響を受けた行の数</returns>
-        public int InsertOrUpdate(TEntity entity)
+        public int InsertOrUpdateByPk(TEntity entity)
         {
             TEntity result = this.SelectByPk(entity);
             if (result == null)

--- a/Sources/OrmTxcSql/Daos/AbstractDao.cs
+++ b/Sources/OrmTxcSql/Daos/AbstractDao.cs
@@ -24,8 +24,8 @@ namespace OrmTxcSql.Daos
         /// </summary>
         protected static readonly string MissingPrimaryKeyExceptionMessage = $"{nameof(PrimaryKeyAttribute)} is not found in {typeof(TEntity).Name}.";
 
-        IEnumerable<IDbCommand> IDao.Commands { get => this.CommandCollection; }
-        private readonly IEnumerable<IDbCommand> CommandCollection;
+        IEnumerable<IDbCommand> IDao.Commands { get => this._commandCollection; }
+        private readonly IEnumerable<IDbCommand> _commandCollection;
 
         /// <summary>
         /// <typeparamref name="TDbCommand"/>を取得します。
@@ -42,7 +42,7 @@ namespace OrmTxcSql.Daos
         /// </summary>
         public AbstractDao()
         {
-            this.CommandCollection = new IDbCommand[] { this.Command };
+            this._commandCollection = new IDbCommand[] { this.Command };
         }
 
         /// <summary>

--- a/Sources/OrmTxcSql/Daos/AbstractDao.cs
+++ b/Sources/OrmTxcSql/Daos/AbstractDao.cs
@@ -24,6 +24,15 @@ namespace OrmTxcSql.Daos
         /// </summary>
         protected static readonly string MissingPrimaryKeyExceptionMessage = $"{nameof(PrimaryKeyAttribute)} is not found in {typeof(TEntity).Name}.";
 
+        /// <summary>
+        /// 例外に設定されるメッセージ：INSERT文を実行する必要がないエンティティが渡された場合
+        /// </summary>
+        protected static readonly string ArgumentExceptionMessageForNoNeedToInsert = $"No property values are set.";
+        /// <summary>
+        /// 例外に設定されるメッセージ：UPDATE文を実行する必要がないエンティティが渡された場合
+        /// </summary>
+        protected static readonly string ArgumentExceptionMessageForNoNeedToUpdate = $"No property values are different to those in data source.";
+
         IEnumerable<IDbCommand> IDao.Commands { get => this._commandCollection; }
         private readonly IEnumerable<IDbCommand> _commandCollection;
 
@@ -126,6 +135,20 @@ namespace OrmTxcSql.Daos
         /// </summary>
         /// <param name="entity"></param>
         /// <returns>影響を受けた行の数</returns>
+        /// <remarks>
+        /// ・このメソッドは、エンティティをデータソースに登録する際に登録したいエンティティがデータソースに存在する／存在しないを気にせずに使用できます。<br/>
+        /// 　- 登録したいエンティティがデータソースに存在しない場合、新規登録されます。（INSERT文）<br/>
+        /// 　- 登録したいエンティティがデータソースに存在する場合、更新されます。（UPDATE文）<br/>
+        /// <br/>
+        /// ・ただし、このメソッドを使用する際は、データソースに何らかの変更が発生することを想定しているため、次の場合には例外が投げられます。<br/>
+        /// 　- 登録したいエンティティのプロパティに値が設定されたものが存在しない。（登録時に設定される値が存在しないため）<br/>
+        /// 　- 登録したいエンティティのプロパティ値がデータソースに存在するエンティティのプロパティとすべて一致している。（更新時に変更が発生しないため）<br/>
+        /// ・このような場合が発生する状況は呼び出し元でプロパティの設定が漏れていることがほとんどだと考えられるため、例外が投げられるようにしています。
+        /// </remarks>
+        /// <exception cref="ArgumentException">
+        /// ・<paramref name="entity"/> のプロパティに値が設定されたものが存在しない。（登録時に設定される値が存在せず、INSERT文を実行する意味がないため）<br/>
+        /// ・<paramref name="entity"/> のプロパティ値がデータソースに存在するエンティティのプロパティとすべて一致している。（更新時に変更が発生せず、UPDATE文を実行する意味がないため）<br/>
+        /// </exception>
         public int InsertOrUpdateByPk(TEntity entity)
         {
             TEntity result = this.SelectByPk(entity);
@@ -133,8 +156,8 @@ namespace OrmTxcSql.Daos
             {
                 if (entity.HasEqualPropertyValues(new TEntity()))
                 {
-                    // 引数のエンティティが初期状態と等価な場合、INSERT文を実行しない。
-                    return 0;
+                    // 例外を投げる：引数のエンティティが初期状態と等価な場合、INSERT文を実行しない。
+                    throw new ArgumentException(ArgumentExceptionMessageForNoNeedToInsert, nameof(entity));
                 }
                 else
                 {
@@ -146,8 +169,8 @@ namespace OrmTxcSql.Daos
             {
                 if (entity.HasEqualPropertyValues(result))
                 {
-                    // 引数のエンティティが検索結果と等価な場合、UPDATE文を実行しない。
-                    return 0;
+                    // 例外を投げる：引数のエンティティが検索結果と等価な場合、UPDATE文を実行しない。
+                    throw new ArgumentException(ArgumentExceptionMessageForNoNeedToUpdate, nameof(entity));
                 }
                 else
                 {

--- a/Sources/OrmTxcSql/Daos/AbstractDao.cs
+++ b/Sources/OrmTxcSql/Daos/AbstractDao.cs
@@ -125,7 +125,7 @@ namespace OrmTxcSql.Daos
         /// レコードの存在有無を確認し、INSERT文、または、UPDATE文を実行する。
         /// </summary>
         /// <param name="entity"></param>
-        /// <returns></returns>
+        /// <returns>影響を受けた行の数</returns>
         public int InsertOrUpdate(TEntity entity)
         {
             TEntity result = this.SelectByPk(entity);

--- a/Sources/OrmTxcSql/OrmTxcSql.nuspec
+++ b/Sources/OrmTxcSql/OrmTxcSql.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>OrmTxcSql</id>
-    <version>1.0.10.1</version>
+    <version>1.1.0</version>
     <authors>tanoue13</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>

--- a/Sources/OrmTxcSql/Properties/AssemblyInfo.cs
+++ b/Sources/OrmTxcSql/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // すべての値を指定するか、次を使用してビルド番号とリビジョン番号を既定に設定できます
 // 既定値にすることができます:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.10.1")]
-[assembly: AssemblyFileVersion("1.0.10.1")]
+[assembly: AssemblyVersion("1.1.0")]
+[assembly: AssemblyFileVersion("1.1.0")]


### PR DESCRIPTION
for issue #18 
・メソッド名を変更（InsertOrUpdate→InsertOrUpdateByPk）
・InsertOrUpdateByPk(TEntity)において、INSERT文、UPDATE文を実行しない場合に例外を投げるように変更。