### PR TITLE
非null属性値のみを更新するUPDATE文を自動生成するメソッドを実装 for issue #21

### DIFF
--- a/Sources/OrmTxcSql.DB2/Daos/DB2Dao.cs
+++ b/Sources/OrmTxcSql.DB2/Daos/DB2Dao.cs
@@ -16,7 +16,7 @@ namespace OrmTxcSql.DB2.Daos
 {
 
     /// <summary>
-    /// Daoの基底クラス。BaseEntityのサブクラスに対してInsert, UpdateByPk, FindByPkを実装済み。
+    /// DB2用のdao。BaseEntityのサブクラスに対してInsert, UpdateByPk, FindByPkを実装済み。
     /// </summary>
     /// <typeparam name="TEntity"></typeparam>
     /// <remarks>

--- a/Sources/OrmTxcSql.DB2/Daos/DB2Dao.cs
+++ b/Sources/OrmTxcSql.DB2/Daos/DB2Dao.cs
@@ -26,7 +26,13 @@ namespace OrmTxcSql.DB2.Daos
     public abstract class DB2Dao<TEntity> : AbstractDao<TEntity, iDB2Command, iDB2DataAdapter>
         where TEntity : DB2Entity, new()
     {
-
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="command"></param>
+        /// <param name="entity"></param>
+        /// <param name="enableOptimisticConcurrency"></param>
+        /// <returns></returns>
         protected override int ExecuteNonQuery(iDB2Command command, TEntity entity, bool enableOptimisticConcurrency = true)
             => DB2Server.ExecuteNonQuery(command, enableOptimisticConcurrency);
 
@@ -50,6 +56,11 @@ namespace OrmTxcSql.DB2.Daos
             // 結果を戻す。
             return result;
         }
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="command"></param>
+        /// <param name="entity"></param>
         protected virtual void BuildInsertCommand(iDB2Command command, TEntity entity)
         {
             // ディクショナリ（カラム名→プロパティ）を生成する。（UID属性なしのカラムのみ）
@@ -131,6 +142,11 @@ namespace OrmTxcSql.DB2.Daos
             // 結果を戻す。
             return result;
         }
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="command"></param>
+        /// <param name="entity"></param>
         protected virtual void BuildUpdateByPkCommand(iDB2Command command, TEntity entity)
         {
             // ディクショナリ（カラム名→プロパティ）を生成する。（主キー属性ありのカラムのみ）
@@ -239,6 +255,16 @@ namespace OrmTxcSql.DB2.Daos
         }
 
         /// <summary>
+        /// 更新する。（１件）（非null項目のみ）
+        /// </summary>
+        /// <param name="entity">entity</param>
+        /// <returns></returns>
+        public override int UpdateUnlessNullByPk(TEntity entity)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         /// 検索する。（１件）
         /// </summary>
         /// <param name="entity"></param>
@@ -279,6 +305,11 @@ namespace OrmTxcSql.DB2.Daos
                     }
             }
         }
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="command"></param>
+        /// <param name="entity"></param>
         protected virtual void BuildSelectByPkCommand(iDB2Command command, TEntity entity)
         {
             // ディクショナリ（カラム名→プロパティ）を生成する。（主キー属性ありのカラムのみ）

--- a/Sources/OrmTxcSql.Npgsql/Daos/NpgsqlDao.cs
+++ b/Sources/OrmTxcSql.Npgsql/Daos/NpgsqlDao.cs
@@ -64,7 +64,7 @@ namespace OrmTxcSql.Npgsql.Daos
             //
             // 対象項目を反復処理し、項目名とSQLパラメータを設定する。
             IEnumerator<KeyValuePair<string, PropertyInfo>> pairs = entity.GetColumnAttributes()
-                // UID属性なしのカラムのみ
+                // UID属性なし
                 .Where(prop => null == prop.GetCustomAttribute<UIDAttribute>(false))
                 // ディクショナリ（カラム名→プロパティ）に変換する。
                 .ToDictionary(prop => prop.GetCustomAttribute<ColumnAttribute>(false).ColumnName)
@@ -103,7 +103,7 @@ namespace OrmTxcSql.Npgsql.Daos
             else
             {
                 // fool-proof: 対象項目が存在しない場合、例外を投げる。
-                throw new ArgumentException("No target property is given.");
+                throw new ArgumentException(ArgumentExceptionMessageForNoTargetPropertyIsGiven);
             }
             //
             // テーブル名を取得する。
@@ -250,7 +250,7 @@ namespace OrmTxcSql.Npgsql.Daos
             else
             {
                 // fool-proof: 更新対象項目が存在しない場合、例外を投げる。
-                throw new ArgumentException("No target property is given.");
+                throw new ArgumentException(ArgumentExceptionMessageForNoTargetPropertyIsGiven);
             }
             //
             // テーブル名を取得する。

--- a/Sources/OrmTxcSql.Npgsql/Daos/NpgsqlDao.cs
+++ b/Sources/OrmTxcSql.Npgsql/Daos/NpgsqlDao.cs
@@ -273,7 +273,23 @@ namespace OrmTxcSql.Npgsql.Daos
             // コマンドの準備に必要なオブジェクトを生成する。
             NpgsqlCommand command = this.Command;
             //
-            // 更新対象項目を取得する。（主キー属性なし、UID属性なし、非null項目のカラムのみ）
+            // コマンドを準備する。
+            this.BuildUpdateUnlessNullByPk(command, entity);
+            //
+            // コマンドを実行する。
+            int result = this.ExecuteNonQuery(command, entity);
+            //
+            // 結果を戻す。
+            return result;
+        }
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="command"></param>
+        /// <param name="entity"></param>
+        protected virtual void BuildUpdateUnlessNullByPk(NpgsqlCommand command, TEntity entity)
+        {
+            // 更新対象項目：主キー属性なし、UID属性なし、非null項目のカラムのみ
             IEnumerable<PropertyInfo> properties = entity.GetColumnAttributes()
                 // 主キー属性なし
                 .Where(prop => null == prop.GetCustomAttribute<PrimaryKeyAttribute>(false))
@@ -284,12 +300,6 @@ namespace OrmTxcSql.Npgsql.Daos
             //
             // コマンドを準備する。
             this.BuildUpdateByPkCommand(command, entity, properties);
-            //
-            // コマンドを実行する。
-            int result = this.ExecuteNonQuery(command, entity);
-            //
-            // 結果を戻す。
-            return result;
         }
 
         /// <summary>

--- a/Sources/OrmTxcSql.Npgsql/Daos/NpgsqlDao.cs
+++ b/Sources/OrmTxcSql.Npgsql/Daos/NpgsqlDao.cs
@@ -16,7 +16,7 @@ namespace OrmTxcSql.Npgsql.Daos
 {
 
     /// <summary>
-    /// PostgreSQL用のdao
+    /// PostgreSQL用のdao。BaseEntityのサブクラスに対してInsert, UpdateByPk, FindByPkを実装済み。
     /// </summary>
     public abstract class NpgsqlDao<TEntity> : AbstractDao<TEntity, NpgsqlCommand, NpgsqlDataAdapter>
         where TEntity : NpgsqlEntity, new()

--- a/Sources/OrmTxcSql.Npgsql/Daos/NpgsqlDao.cs
+++ b/Sources/OrmTxcSql.Npgsql/Daos/NpgsqlDao.cs
@@ -201,6 +201,12 @@ namespace OrmTxcSql.Npgsql.Daos
         }
         private void BuildUpdateCommand(NpgsqlCommand command, TEntity entity, IEnumerable<PropertyInfo> properties, string filter)
         {
+            // validation; 更新対象項目が存在しない場合、例外を投げる。
+            if ((null == properties) || (properties.Count() <= 0))
+            {
+                throw new ArgumentException("No target property is given.");
+            }
+            //
             // ディクショナリ（カラム名→プロパティ）を生成する。
             Dictionary<string, PropertyInfo> dictionary = properties.ToDictionary(prop => prop.GetCustomAttribute<ColumnAttribute>(false).ColumnName);
             // テーブル名を取得する。

--- a/Sources/OrmTxcSql.SqlClient/Daos/SqlDao.cs
+++ b/Sources/OrmTxcSql.SqlClient/Daos/SqlDao.cs
@@ -64,7 +64,7 @@ namespace OrmTxcSql.SqlClient.Daos
             //
             // 対象項目を反復処理し、項目名とSQLパラメータを設定する。
             IEnumerator<KeyValuePair<string, PropertyInfo>> pairs = entity.GetColumnAttributes()
-                // UID属性なしのカラムのみ
+                // UID属性なし
                 .Where(prop => null == prop.GetCustomAttribute<UIDAttribute>(false))
                 // ディクショナリ（カラム名→プロパティ）に変換する。
                 .ToDictionary(prop => prop.GetCustomAttribute<ColumnAttribute>(false).ColumnName)
@@ -103,7 +103,7 @@ namespace OrmTxcSql.SqlClient.Daos
             else
             {
                 // fool-proof: 対象項目が存在しない場合、例外を投げる。
-                throw new ArgumentException("No target property is given.");
+                throw new ArgumentException(ArgumentExceptionMessageForNoTargetPropertyIsGiven);
             }
             //
             // テーブル名を取得する。
@@ -250,7 +250,7 @@ namespace OrmTxcSql.SqlClient.Daos
             else
             {
                 // fool-proof: 更新対象項目が存在しない場合、例外を投げる。
-                throw new ArgumentException("No target property is given.");
+                throw new ArgumentException(ArgumentExceptionMessageForNoTargetPropertyIsGiven);
             }
             //
             // テーブル名を取得する。

--- a/Sources/OrmTxcSql.SqlClient/Daos/SqlDao.cs
+++ b/Sources/OrmTxcSql.SqlClient/Daos/SqlDao.cs
@@ -58,18 +58,18 @@ namespace OrmTxcSql.SqlClient.Daos
         /// <param name="entity"></param>
         protected virtual void BuildInsertCommand(SqlCommand command, TEntity entity)
         {
-            // ディクショナリ（カラム名→プロパティ）を生成する。（UID属性なしのカラムのみ）
-            Dictionary<string, PropertyInfo> dictionary = entity.GetColumnAttributes()
-                .Where(prop => null == prop.GetCustomAttribute<UIDAttribute>(false))
-                .ToDictionary(prop => prop.GetCustomAttribute<ColumnAttribute>(false).ColumnName);
-            // テーブル名を取得する。
-            string tableName = entity.GetTableName();
-            //
             // コマンドの準備に必要なオブジェクトを生成する。
             var columnStringBuilder = new StringBuilder();
             var valueStringBuilder = new StringBuilder();
             //
-            IEnumerator<KeyValuePair<string, PropertyInfo>> pairs = dictionary.GetEnumerator();
+            // 対象項目を反復処理し、項目名とSQLパラメータを設定する。
+            IEnumerator<KeyValuePair<string, PropertyInfo>> pairs = entity.GetColumnAttributes()
+                // UID属性なしのカラムのみ
+                .Where(prop => null == prop.GetCustomAttribute<UIDAttribute>(false))
+                // ディクショナリ（カラム名→プロパティ）に変換する。
+                .ToDictionary(prop => prop.GetCustomAttribute<ColumnAttribute>(false).ColumnName)
+                // IEnumeratorを取得する。
+                .GetEnumerator();
             if (pairs.MoveNext())
             {
                 // １件目についての処理：
@@ -100,7 +100,14 @@ namespace OrmTxcSql.SqlClient.Daos
                     SqlServer.AddParameterOrReplace(command, parameterName, entity, propertyInfo);
                 }
             }
+            else
+            {
+                // fool-proof: 対象項目が存在しない場合、例外を投げる。
+                throw new ArgumentException("No target property is given.");
+            }
             //
+            // テーブル名を取得する。
+            string tableName = entity.GetTableName();
             // コマンドテキストを生成する。
             var builder = new StringBuilder();
             builder.Append(" insert into ").Append(tableName).Append(" (");
@@ -144,20 +151,27 @@ namespace OrmTxcSql.SqlClient.Daos
         /// <param name="entity"></param>
         protected virtual void BuildUpdateByPkCommand(SqlCommand command, TEntity entity)
         {
-            // ディクショナリ（カラム名→プロパティ）を生成する。（主キー属性ありのカラムのみ）
-            Dictionary<string, PropertyInfo> dictionary = entity.GetColumnAttributes()
-                .Where(prop => null != prop.GetCustomAttribute<PrimaryKeyAttribute>(false))
-                .ToDictionary(prop => prop.GetCustomAttribute<ColumnAttribute>(false).ColumnName);
-            // validation: 主キー属性ありのカラムが存在しない場合、例外を投げる。
-            if (dictionary.Count() <= 0)
-            {
-                throw new MissingPrimaryKeyException(MissingPrimaryKeyExceptionMessage);
-            }
+            // 更新対象項目を取得する。（主キー属性なし、UID属性なしのカラムのみ）
+            IEnumerable<PropertyInfo> properties = entity.GetColumnAttributes()
+                .Where(prop => null == prop.GetCustomAttribute<PrimaryKeyAttribute>(false))
+                .Where(prop => null == prop.GetCustomAttribute<UIDAttribute>(false));
             //
+            // コマンドを準備する。
+            this.BuildUpdateByPkCommand(command, entity, properties);
+        }
+        private void BuildUpdateByPkCommand(SqlCommand command, TEntity entity, IEnumerable<PropertyInfo> properties)
+        {
             // コマンドの準備に必要なオブジェクトを生成する。
             var builder = new StringBuilder();
             //
-            IEnumerator<KeyValuePair<string, PropertyInfo>> pairs = dictionary.GetEnumerator();
+            // 主キー項目を反復処理する。
+            IEnumerator<KeyValuePair<string, PropertyInfo>> pairs = EntityUtils
+                // 主キー属性を取得する。
+                .GetPrimaryKeyAttributes<TEntity>()
+                // ディクショナリ（カラム名→プロパティ）に変換する。
+                .ToDictionary(prop => prop.GetCustomAttribute<ColumnAttribute>(false).ColumnName)
+                // IEnumeratorを取得する。
+                .GetEnumerator();
             if (pairs.MoveNext())
             {
                 // １件目についての処理：
@@ -186,23 +200,25 @@ namespace OrmTxcSql.SqlClient.Daos
                 // 共通項目についての処理：
                 builder.Append(this.GetCommonFieldForUpdateCondition("x", true));
             }
+            else
+            {
+                // fool-proof: 主キー属性ありのカラムが存在しない場合、例外を投げる。
+                throw new MissingPrimaryKeyException(MissingPrimaryKeyExceptionMessage);
+            }
             //
-            this.BuildUpdateCommand(command, entity, builder.ToString());
+            this.BuildUpdateCommand(command, entity, properties, builder.ToString());
         }
-        private void BuildUpdateCommand(SqlCommand command, TEntity entity, string filter)
+        private void BuildUpdateCommand(SqlCommand command, TEntity entity, IEnumerable<PropertyInfo> properties, string filter)
         {
-            // ディクショナリ（カラム名→プロパティ）を生成する。（主キー属性なし、UID属性なしのカラムのみ）
-            Dictionary<string, PropertyInfo> dictionary = entity.GetColumnAttributes()
-                .Where(prop => null == prop.GetCustomAttribute<PrimaryKeyAttribute>(false))
-                .Where(prop => null == prop.GetCustomAttribute<UIDAttribute>(false))
-                .ToDictionary(prop => prop.GetCustomAttribute<ColumnAttribute>(false).ColumnName);
-            // テーブル名を取得する。
-            string tableName = entity.GetTableName();
-            //
             // コマンドの準備に必要なオブジェクトを生成する。
             var columnStringBuilder = new StringBuilder();
-            // 更新列とSQLパラメータを設定する。
-            IEnumerator<KeyValuePair<string, PropertyInfo>> pairs = dictionary.GetEnumerator();
+            //
+            // 対象項目を反復処理し、更新列とSQLパラメータを設定する。
+            IEnumerator<KeyValuePair<string, PropertyInfo>> pairs = properties
+                // ディクショナリ（カラム名→プロパティ）に変換する。
+                .ToDictionary(prop => prop.GetCustomAttribute<ColumnAttribute>(false).ColumnName)
+                // IEnumeratorを取得する。
+                .GetEnumerator();
             if (pairs.MoveNext())
             {
                 // １件目についての処理：
@@ -231,7 +247,14 @@ namespace OrmTxcSql.SqlClient.Daos
                 // 共通項目についての処理：
                 columnStringBuilder.Append(this.GetCommonFieldForUpdate(true));
             }
+            else
+            {
+                // fool-proof: 更新対象項目が存在しない場合、例外を投げる。
+                throw new ArgumentException("No target property is given.");
+            }
             //
+            // テーブル名を取得する。
+            string tableName = entity.GetTableName();
             // コマンドテキストを生成する。
             // 開発者向けコメント：（fool-proof：条件の前に、空白を１つはさむ）
             // OK: update table_name set a = @a, b = @b, c = @c where x = @x
@@ -256,7 +279,37 @@ namespace OrmTxcSql.SqlClient.Daos
         /// <returns></returns>
         public override int UpdateUnlessNullByPk(TEntity entity)
         {
-            throw new NotImplementedException();
+            //
+            // コマンドの準備に必要なオブジェクトを生成する。
+            SqlCommand command = this.Command;
+            //
+            // コマンドを準備する。
+            this.BuildUpdateUnlessNullByPk(command, entity);
+            //
+            // コマンドを実行する。
+            int result = this.ExecuteNonQuery(command, entity);
+            //
+            // 結果を戻す。
+            return result;
+        }
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="command"></param>
+        /// <param name="entity"></param>
+        protected virtual void BuildUpdateUnlessNullByPk(SqlCommand command, TEntity entity)
+        {
+            // 更新対象項目：主キー属性なし、UID属性なし、非null項目のカラムのみ
+            IEnumerable<PropertyInfo> properties = entity.GetColumnAttributes()
+                // 主キー属性なし
+                .Where(prop => null == prop.GetCustomAttribute<PrimaryKeyAttribute>(false))
+                // UID属性なし
+                .Where(prop => null == prop.GetCustomAttribute<UIDAttribute>(false))
+                // 非null項目
+                .Where(prop => null != prop.GetValue(entity));
+            //
+            // コマンドを準備する。
+            this.BuildUpdateByPkCommand(command, entity, properties);
         }
 
         /// <summary>
@@ -307,20 +360,17 @@ namespace OrmTxcSql.SqlClient.Daos
         /// <param name="entity"></param>
         protected virtual void BuildSelectByPkCommand(SqlCommand command, TEntity entity)
         {
-            // ディクショナリ（カラム名→プロパティ）を生成する。（主キー属性ありのカラムのみ）
-            Dictionary<string, PropertyInfo> dictionary = entity.GetColumnAttributes()
-                .Where(prop => null != prop.GetCustomAttribute<PrimaryKeyAttribute>(false))
-                .ToDictionary(prop => prop.GetCustomAttribute<ColumnAttribute>(false).ColumnName);
-            // validation: 主キー属性ありのカラムが存在しない場合、例外を投げる。
-            if (dictionary.Count() <= 0)
-            {
-                throw new MissingPrimaryKeyException(MissingPrimaryKeyExceptionMessage);
-            }
-            //
             // コマンドの準備に必要なオブジェクトを生成する。
             var builder = new StringBuilder();
             //
-            IEnumerator<KeyValuePair<string, PropertyInfo>> pairs = dictionary.GetEnumerator();
+            // 主キー項目を反復処理する。
+            IEnumerator<KeyValuePair<string, PropertyInfo>> pairs = EntityUtils
+                // 主キー属性を取得する。
+                .GetPrimaryKeyAttributes<TEntity>()
+                // ディクショナリ（カラム名→プロパティ）に変換する。
+                .ToDictionary(prop => prop.GetCustomAttribute<ColumnAttribute>(false).ColumnName)
+                // IEnumeratorを取得する。
+                .GetEnumerator();
             if (pairs.MoveNext())
             {
                 // １件目についての処理：
@@ -348,6 +398,11 @@ namespace OrmTxcSql.SqlClient.Daos
                 }
                 // 共通項目についての処理：
                 builder.Append(this.GetCommonFieldForSelectCondition("x", true));
+            }
+            else
+            {
+                // fool-proof: 主キー属性ありのカラムが存在しない場合、例外を投げる。
+                throw new MissingPrimaryKeyException(MissingPrimaryKeyExceptionMessage);
             }
             //
             this.BuildSelectCommand(command, entity, builder.ToString());

--- a/Sources/OrmTxcSql.SqlClient/Daos/SqlDao.cs
+++ b/Sources/OrmTxcSql.SqlClient/Daos/SqlDao.cs
@@ -16,7 +16,7 @@ namespace OrmTxcSql.SqlClient.Daos
 {
 
     /// <summary>
-    /// SQL Server用のdao
+    /// SQL Server用のdao。BaseEntityのサブクラスに対してInsert, UpdateByPk, FindByPkを実装済み。
     /// </summary>
     public abstract class SqlDao<TEntity> : AbstractDao<TEntity, SqlCommand, SqlDataAdapter>
         where TEntity : SqlEntity, new()

--- a/Sources/OrmTxcSql.SqlClient/Daos/SqlDao.cs
+++ b/Sources/OrmTxcSql.SqlClient/Daos/SqlDao.cs
@@ -21,7 +21,13 @@ namespace OrmTxcSql.SqlClient.Daos
     public abstract class SqlDao<TEntity> : AbstractDao<TEntity, SqlCommand, SqlDataAdapter>
         where TEntity : SqlEntity, new()
     {
-
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="command"></param>
+        /// <param name="entity"></param>
+        /// <param name="enableOptimisticConcurrency"></param>
+        /// <returns></returns>
         protected override int ExecuteNonQuery(SqlCommand command, TEntity entity, bool enableOptimisticConcurrency = true)
             => SqlServer.ExecuteNonQuery(command, enableOptimisticConcurrency);
 
@@ -45,6 +51,11 @@ namespace OrmTxcSql.SqlClient.Daos
             // 結果を戻す。
             return result;
         }
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="command"></param>
+        /// <param name="entity"></param>
         protected virtual void BuildInsertCommand(SqlCommand command, TEntity entity)
         {
             // ディクショナリ（カラム名→プロパティ）を生成する。（UID属性なしのカラムのみ）
@@ -126,6 +137,11 @@ namespace OrmTxcSql.SqlClient.Daos
             // 結果を戻す。
             return result;
         }
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="command"></param>
+        /// <param name="entity"></param>
         protected virtual void BuildUpdateByPkCommand(SqlCommand command, TEntity entity)
         {
             // ディクショナリ（カラム名→プロパティ）を生成する。（主キー属性ありのカラムのみ）
@@ -234,6 +250,16 @@ namespace OrmTxcSql.SqlClient.Daos
         }
 
         /// <summary>
+        /// 更新する。（１件）（非null項目のみ）
+        /// </summary>
+        /// <param name="entity">entity</param>
+        /// <returns></returns>
+        public override int UpdateUnlessNullByPk(TEntity entity)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         /// 検索する。（１件）
         /// </summary>
         /// <param name="entity"></param>
@@ -274,6 +300,11 @@ namespace OrmTxcSql.SqlClient.Daos
                     }
             }
         }
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="command"></param>
+        /// <param name="entity"></param>
         protected virtual void BuildSelectByPkCommand(SqlCommand command, TEntity entity)
         {
             // ディクショナリ（カラム名→プロパティ）を生成する。（主キー属性ありのカラムのみ）

--- a/Sources/OrmTxcSql/Daos/AbstractDao.cs
+++ b/Sources/OrmTxcSql/Daos/AbstractDao.cs
@@ -33,6 +33,11 @@ namespace OrmTxcSql.Daos
         /// 例外に設定されるメッセージ：UPDATE文を実行する必要がないエンティティが渡された場合
         /// </summary>
         protected static readonly string ArgumentExceptionMessageForNoNeedToUpdate = $"No property values are different to those in data source.";
+       
+        /// <summary>
+        /// 例外に設定されるメッセージ：対象プロパティが与えられていない場合
+        /// </summary>
+        protected static readonly string ArgumentExceptionMessageForNoTargetPropertyIsGiven = $"No target property is given.";
 
         IEnumerable<IDbCommand> IDao.Commands { get => this._commandCollection; }
         private readonly IEnumerable<IDbCommand> _commandCollection;

--- a/Sources/OrmTxcSql/Daos/AbstractDao.cs
+++ b/Sources/OrmTxcSql/Daos/AbstractDao.cs
@@ -68,6 +68,12 @@ namespace OrmTxcSql.Daos
         /// <param name="entity">entity</param>
         /// <returns></returns>
         public abstract int UpdateByPk(TEntity entity);
+        /// <summary>
+        /// 更新する。（１件）（非null項目のみ）
+        /// </summary>
+        /// <param name="entity">entity</param>
+        /// <returns></returns>
+        public abstract int UpdateUnlessNullByPk(TEntity entity);
 
         /// <summary>
         /// 検索する。（１件）

--- a/Sources/OrmTxcSql/Utils/EntityUtils.cs
+++ b/Sources/OrmTxcSql/Utils/EntityUtils.cs
@@ -56,7 +56,7 @@ namespace OrmTxcSql.Utils
         public static IEnumerable<PropertyInfo> GetColumnAttributes<TEntity>() where TEntity : AbstractEntity
             => EntityUtils.GetColumnAttributes(typeof(TEntity));
         /// <summary>
-        /// カラム名を取得する。
+        /// カラム属性を取得する。
         /// </summary>
         /// <param name="type"></param>
         /// <returns></returns>
@@ -66,6 +66,33 @@ namespace OrmTxcSql.Utils
             IEnumerable<PropertyInfo> attributes = type
                 .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
                 .Where(prop => null != prop.GetCustomAttribute<ColumnAttribute>(false));
+            // 結果を戻す。
+            return attributes;
+        }
+
+        /// <summary>
+        /// 主キー属性を取得する。
+        /// </summary>
+        /// <param name="abstractEntity"></param>
+        /// <returns></returns>
+        public static IEnumerable<PropertyInfo> GetPrimaryKeyAttributes(this AbstractEntity abstractEntity)
+            => EntityUtils.GetPrimaryKeyAttributes(abstractEntity.GetType());
+        /// <summary>
+        /// 主キー属性を取得する。
+        /// </summary>
+        /// <returns></returns>
+        public static IEnumerable<PropertyInfo> GetPrimaryKeyAttributes<TEntity>() where TEntity : AbstractEntity
+            => EntityUtils.GetPrimaryKeyAttributes(typeof(TEntity));
+        /// <summary>
+        /// 主キー属性を取得する。
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        private static IEnumerable<PropertyInfo> GetPrimaryKeyAttributes(Type type)
+        {
+            // 主キー属性を取得する。
+            IEnumerable<PropertyInfo> attributes = EntityUtils.GetColumnAttributes(type)
+                .Where(prop => null != prop.GetCustomAttribute<PrimaryKeyAttribute>(false));
             // 結果を戻す。
             return attributes;
         }


### PR DESCRIPTION
for issue #21 
・EntityUtilsに主キー属性を取得するメソッドを追加：GetPrimaryKeyAttributes
・AbstractDaoに非null項目のみ更新するメソッドを追加：UpdateUnlessNullByPk
　- NpgsqlDaoで実装＆テスト。
　- DB2Dao, SqlDaoは、NpgsqlDaoの実装を横展開。
・カラムを扱う処理について、コードを見直し。